### PR TITLE
1.1.1 - Add ko-fi donation link to readme.txt and plugin actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 # Link Verification for Mastodon
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/over-engineer/link-verification-for-mastodon/deploy-to-plugin-repository)](https://github.com/over-engineer/link-verification-for-mastodon/actions/workflows/deploy.yml)
 [![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/link-verification-for-mastodon)](https://wordpress.org/plugins/link-verification-for-mastodon/)
 [![WordPress Plugin: Tested WP Version](https://img.shields.io/wordpress/plugin/tested/link-verification-for-mastodon)](https://wordpress.org/plugins/link-verification-for-mastodon/)
 [![WordPress Plugin Rating](https://img.shields.io/wordpress/plugin/stars/link-verification-for-mastodon)](https://wordpress.org/plugins/link-verification-for-mastodon/)

--- a/admin/donation.php
+++ b/admin/donation.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Donation link.
+ *
+ * @package    OverEngineer\Mastodon\LinkVerification
+ * @subpackage Admin
+ * @since      1.1.1
+ *
+ * @copyright 2023 Konstantinos Pappas <dev@over-engineer.com>
+ */
+
+namespace OverEngineer\Mastodon\LinkVerification\Admin;
+
+use const OverEngineer\Mastodon\LinkVerification\PLUGIN_FILE;
+use const OverEngineer\Mastodon\LinkVerification\PLUGIN_URL;
+use const OverEngineer\Mastodon\LinkVerification\VERSION;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    die( 'Forbidden' );
+}
+
+/**
+ * Filter the action links displayed for this plugin to add a donation link.
+ *
+ * @param string[] $actions     An array of plugin action links.
+ * @param string   $plugin_file Path to the plugin file relative to the `plugins` directory.
+ *
+ * @return string[] Plugin action links including the donation link.
+ */
+function add_donation_link( $actions, $plugin_file ) {
+    if ( plugin_basename( PLUGIN_FILE ) !== $plugin_file ) {
+        return $actions;
+    }
+
+    $actions['donate'] = sprintf(
+        '<a href="%1$s" target="_blank" rel="noopener noreferrer" class="overengineer-link-verification-action-link">%2$s<span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+        esc_url( 'https://ko-fi.com/overengineer' ),
+        esc_html__( 'Buy me a coffee', 'link-verification-for-mastodon' ),
+        /* translators: Accessibility text. */
+        esc_html__( '(opens in a new tab)', 'link-verification-for-mastodon' )
+    );
+
+    return $actions;
+}
+
+/**
+ * Enqueue stylesheet on the plugins page.
+ *
+ * @param string $hook The current admin page.
+ *
+ * @return void
+ */
+function enqueue_installed_plugins_style( $hook ) {
+    if ( $hook !== 'plugins.php' ) {
+        // Not on the plugins page, bail early
+        return;
+    }
+
+    wp_enqueue_style(
+        'overengineer-link-verification-installed-plugins',
+        PLUGIN_URL . 'assets/css/admin-styles.css',
+        array(), // no dependencies
+        VERSION
+    );
+}
+
+add_filter( 'plugin_action_links', 'OverEngineer\Mastodon\LinkVerification\Admin\add_donation_link', 10, 2 );
+add_action( 'admin_enqueue_scripts', 'OverEngineer\Mastodon\LinkVerification\Admin\enqueue_installed_plugins_style' );

--- a/assets/css/admin-styles.css
+++ b/assets/css/admin-styles.css
@@ -1,0 +1,14 @@
+.plugins .plugin-title .overengineer-link-verification-action-link .dashicons {
+    float: none;
+    padding: 0;
+    width: inherit;
+    height: inherit;
+}
+
+.plugins .plugin-title .overengineer-link-verification-action-link .dashicons::before {
+    padding: inherit;
+    background-color: inherit;
+    box-shadow: none;
+    font-size: inherit;
+    color: inherit;
+}

--- a/assets/css/index.php
+++ b/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/link-verification-for-mastodon.php
+++ b/link-verification-for-mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Link Verification for Mastodon
  * Plugin URI: https://over-engineer.com/projects/link-verification-for-mastodon
  * Description: A WordPress plugin to quickly verify a link on your Mastodon profile.
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: overengineer
  * Author URI: https://over-engineer.com/
  * Text Domain: link-verification-for-mastodon
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Plugin' ) ) :
         /**
          * @var string Plugin version number.
          */
-        private $version = '1.1.0';
+        private $version = '1.1.1';
 
         /**
          * @return void
@@ -93,6 +93,7 @@ if ( ! class_exists( 'Plugin' ) ) :
             require_once __DIR__ . '/includes/class-utils.php';
 
             require_once __DIR__ . '/admin/settings.php';
+            require_once __DIR__ . '/admin/donation.php';
             require_once __DIR__ . '/includes/verification-tag.php';
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Plugin URI: https://over-engineer.com/projects/link-verification-for-mastodon
 Contributors: overengineer
 Tags: mastodon, fediverse, social
 Requires at least: 4.4
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 5.6.20
-Stable Tag: 1.1.0
+Stable Tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,11 +54,19 @@ Yes, you can. Just enter all usernames separated by a comma.
 
 If you have spotted any bugs, or would like to request additional features from the plugin, please [file an issue](https://github.com/over-engineer/link-verification-for-mastodon/issues).
 
+= How can I support the developer of this plugin? =
+
+Supporting me is 100% optional. The plugin is free and will always be free. However, if you’d like to support me, it would mean the world to me and help me to keep creating useful plugins. If you’d like to contribute, please consider [buying me a coffee](https://ko-fi.com/overengineer)! ❤️
+
 == Screenshots ==
 
 1. Plugin settings
 
 == Changelog ==
+
+= 1.1.1: April 10, 2023 =
+
+* Add donation link to readme.txt and the plugin’s action links
 
 = 1.1.0: February 26, 2023 =
 


### PR DESCRIPTION
Preparing version `1.1.1`

Changelog
---

* Add donation link to `readme.txt` and the plugin’s action links