### PR TITLE
General: avoid PHP warnings when first setting up the plugin

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -79,7 +79,7 @@ function render_field_mastodon_username() {
     <input type="text"
            name="mastodon_link_verification_settings[mastodon_username]"
            placeholder="@yourusername@your.mastodon.instance"
-           value="<?php echo $username; ?>" />
+           value="<?php echo esc_attr( $username ); ?>" />
 
     <?php
 }

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -72,13 +72,14 @@ function settings_init() {
 }
 
 function render_field_mastodon_username() {
-    $options = get_option( 'mastodon_link_verification_settings' );
+    $options  = get_option( 'mastodon_link_verification_settings' );
+    $username = $options['mastodon_username'] ?? '';
     ?>
 
     <input type="text"
            name="mastodon_link_verification_settings[mastodon_username]"
            placeholder="@yourusername@your.mastodon.instance"
-           value="<?php echo $options['mastodon_username']; ?>" />
+           value="<?php echo $username; ?>" />
 
     <?php
 }

--- a/includes/verification-tag.php
+++ b/includes/verification-tag.php
@@ -64,6 +64,7 @@ function add_verification_tag( $mastodon_username ) {
  */
 function add_verification_tags() {
     $options           = get_option( 'mastodon_link_verification_settings' );
+    $mastodon_username = $options['mastodon_username'] ?? '';
     $mastodon_username = apply_filters( 'mastodon_link_verification_username', $options['mastodon_username'] );
 
     if ( empty( $mastodon_username ) ) {


### PR DESCRIPTION
When you first install the plugin and haven't added any Mastodon username to the plugin settings, you'll get some PHP notices and warnings that can be prevented by adding some default values.

This PR does just that. 

I also took the opportunity to add escaping to the username displayed in admin settings.