### PR TITLE
1.1.2 - Set default values to avoid PHP warnings and escape usernames

### DIFF
--- a/link-verification-for-mastodon.php
+++ b/link-verification-for-mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Link Verification for Mastodon
  * Plugin URI: https://over-engineer.com/projects/link-verification-for-mastodon
  * Description: A WordPress plugin to quickly verify a link on your Mastodon profile.
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: overengineer
  * Author URI: https://over-engineer.com/
  * Text Domain: link-verification-for-mastodon
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Plugin' ) ) :
         /**
          * @var string Plugin version number.
          */
-        private $version = '1.1.1';
+        private $version = '1.1.2';
 
         /**
          * @return void

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Plugin URI: https://over-engineer.com/projects/link-verification-for-mastodon
 Contributors: overengineer
 Tags: mastodon, fediverse, social
 Requires at least: 4.4
-Tested up to: 6.2
+Tested up to: 6.4
 Requires PHP: 5.6.20
-Stable Tag: 1.1.1
+Stable Tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,11 @@ Supporting me is 100% optional. The plugin is free and will always be free. Howe
 1. Plugin settings
 
 == Changelog ==
+
+= 1.1.2: December 13, 2023 =
+
+* Set default values to avoid PHP warnings when the plugin is activated for the first time (thanks to @jeherve)
+* Escape Mastodon usernames in the plugin’s settings page (thanks to @jeherve)
 
 = 1.1.1: April 15, 2023 =
 


### PR DESCRIPTION
Preparing version `1.1.2`

Changelog
---

* Set default values to avoid PHP warnings when the plugin is activated for the first time (thanks to @jeherve)
* Escape Mastodon usernames in the plugin’s settings page (thanks to @jeherve)