### PR TITLE
1.1.3 - Fix verification tag when Mastodon username is empty

### DIFF
--- a/includes/verification-tag.php
+++ b/includes/verification-tag.php
@@ -65,7 +65,7 @@ function add_verification_tag( $mastodon_username ) {
 function add_verification_tags() {
     $options           = get_option( 'mastodon_link_verification_settings' );
     $mastodon_username = $options['mastodon_username'] ?? '';
-    $mastodon_username = apply_filters( 'mastodon_link_verification_username', $options['mastodon_username'] );
+    $mastodon_username = apply_filters( 'mastodon_link_verification_username', $mastodon_username );
 
     if ( empty( $mastodon_username ) ) {
         // Mastodon username is not set, bail early

--- a/link-verification-for-mastodon.php
+++ b/link-verification-for-mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Link Verification for Mastodon
  * Plugin URI: https://over-engineer.com/projects/link-verification-for-mastodon
  * Description: A WordPress plugin to quickly verify a link on your Mastodon profile.
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: overengineer
  * Author URI: https://over-engineer.com/
  * Text Domain: link-verification-for-mastodon
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Plugin' ) ) :
         /**
          * @var string Plugin version number.
          */
-        private $version = '1.1.2';
+        private $version = '1.1.3';
 
         /**
          * @return void

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,10 @@ Supporting me is 100% optional. The plugin is free and will always be free. Howe
 
 == Changelog ==
 
+= 1.1.3: August 5, 2024 =
+
+* Fix verification tag when Mastodon username is empty
+
 = 1.1.2: December 13, 2023 =
 
 * Set default values to avoid PHP warnings when the plugin is activated for the first time (thanks to @jeherve)

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: mastodon, fediverse, social
 Requires at least: 4.4
 Tested up to: 6.4
 Requires PHP: 5.6.20
-Stable Tag: 1.1.2
+Stable Tag: 1.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Preparing version `1.1.3`

Changelog
---

* Fix verification tag when Mastodon username is empty